### PR TITLE
hot reloading with stitching directives

### DIFF
--- a/06-hot-reloading-with-directives/README.md
+++ b/06-hot-reloading-with-directives/README.md
@@ -1,0 +1,95 @@
+# Example 6 – Using stitching directives
+
+This example demonstrates the use of stitching directives to specify type merging configuration. The `@graphql-tools/stitching-directives` package provides importable directives that can be used to annotate types and fields within subschemas, a validator to ensure the directives are used appropriately, and a configuration transformer that can be used on the gateway to convert the subschema directives into explicit configuration setting.
+
+The service setup in this example is based on the [official demonstration repository](https://github.com/apollographql/federation-demo) for
+[Apollo Federation](https://www.apollographql.com/docs/federation/).
+
+**This example demonstrates:**
+
+- Adding remote schemas, with typedefs + custom directives exposed on each subschema via a custom root field.
+- Use of the @key, @computed and @merge directives from `@graphql-tools/stitching-directives` to specify subschema merge configuration.
+- Use of a custom executor that times out a request after a pre-specified limit.
+- Addition of custom queries/mutations on the gateway for listing/modifying the configured services.
+- Hot reloading of the gateway schema based on the available services, responsive to "push" input of service changes via mutations with "pull" input of service health via polling the SDL.  
+
+## Setup
+
+```shell
+cd 06-hot-reloading-with-directives.
+
+yarn install
+start-service-accounts
+```
+
+Then, in a separate terminal tab:
+
+```shell
+start-service-inventory
+```
+
+In a third terminal tab:
+
+```shell
+start-service-products
+```
+
+In a fourth terminal tab:
+
+```shell
+start-service-reviews
+```
+
+And, finally, in a fifth terminal tab:
+
+```shell
+yarn start-gateway
+```
+
+The following services are available for interactive queries:
+
+- **Stitched gateway:** http://localhost:4000/graphql
+- _Accounts subservice_: http://localhost:4001/graphql
+- _Inventory subservice_: http://localhost:4002/graphql
+- _Products subservice_: http://localhost:4003/graphql
+- _Reviews subservice_: http://localhost:4004/graphql
+
+## Summary
+
+Visit the [stitched gateway](http://localhost:4000/graphql) and try running the following query:
+
+```graphql
+query {
+  allEndpoints {
+    url
+  }
+}
+```
+
+Note that the available types and root fields reflect all four of the services returned.
+
+Then, try the following mutation:
+
+```graphql
+mutation {
+  removeEndpoint(url: "http://localhost:4004/graphql") {
+    success
+  }
+}
+```
+
+Reload the [stitched gateway](http://localhost:4000/graphql) and see how the available types and root fields automatically adjust after the Reviews service has been removed from the gateway.
+
+Then, try the following mutation:
+
+```graphql
+mutation {
+  addEndpoint(url: "http://localhost:4004/graphql") {
+    success
+  }
+}
+```
+
+Reload the [stitched gateway](http://localhost:4000/graphql) and see how the available types and root fields have been restored.
+
+Finally, try stopping the Review service by closing its terminal. Reload the [stitched gateway](http://localhost:4000/graphql) to once again see how the available types and root fields adjust automatically.

--- a/06-hot-reloading-with-directives/README.md
+++ b/06-hot-reloading-with-directives/README.md
@@ -1,17 +1,21 @@
-# Example 6 – Using stitching directives
+# Example 6 – Hot reloading with stitching directives
 
-This example demonstrates the use of stitching directives to specify type merging configuration. The `@graphql-tools/stitching-directives` package provides importable directives that can be used to annotate types and fields within subschemas, a validator to ensure the directives are used appropriately, and a configuration transformer that can be used on the gateway to convert the subschema directives into explicit configuration setting.
+This example demonstrates the use of stitching directives to specify type merging configuration. Moving service-specific configuration out of the gateway facilitates service setup automation, facilitating hot-reloading.
 
-The service setup in this example is based on the [official demonstration repository](https://github.com/apollographql/federation-demo) for
+The `@graphql-tools/stitching-directives` package provides importable directives that can be used to annotate types and fields within subschemas, a validator to ensure the directives are used appropriately, and a configuration transformer that can be used on the gateway to convert the subschema directives into explicit configuration setting.
+
+The gateway server can refresh the schema in response to "push" input of service changes via mutations as well as "pull" input of service health via subschema SDL polling.
+
+Note: the service setup in this example is based on the [official demonstration repository](https://github.com/apollographql/federation-demo) for
 [Apollo Federation](https://www.apollographql.com/docs/federation/).
 
 **This example demonstrates:**
 
-- Adding remote schemas, with typedefs + custom directives exposed on each subschema via a custom root field.
-- Use of the @key, @computed and @merge directives from `@graphql-tools/stitching-directives` to specify subschema merge configuration.
+- Adding remote schemas, with typedefs and custom directives exposed via a custom root field.
+- Use of the @key, @computed and @merge directives to specify type merging configuration.
 - Use of a custom executor that times out a request after a pre-specified limit.
 - Addition of custom queries/mutations on the gateway for listing/modifying the configured services.
-- Hot reloading of the gateway schema based on the available services, responsive to "push" input of service changes via mutations with "pull" input of service health via polling the SDL.  
+- Hot reloading of the gateway schema based on "push" input of service changes and "pull" input of service health.
 
 ## Setup
 

--- a/06-hot-reloading-with-directives/index.js
+++ b/06-hot-reloading-with-directives/index.js
@@ -1,0 +1,110 @@
+const express = require('express');
+const { graphqlHTTP } = require('express-graphql');
+const { stitchSchemas } = require('@graphql-tools/stitch');
+const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
+const { buildSchema } = require('graphql');
+
+const readFileSync = require('./lib/read_file_sync');
+
+const { stitchingDirectivesTypeDefs, stitchingDirectivesTransformer } = stitchingDirectives();
+
+const makeRemoteExecutorWithTimeout = require('./lib/make_remote_executor_with_timeout');
+
+const SDL_TIMEOUT = 200;
+const OPERATION_TIMEOUT = 5000;
+
+const typeDefs = `
+  ${stitchingDirectivesTypeDefs}
+  ${readFileSync(__dirname, 'schema.graphql')}
+`;
+
+const resolvers = {
+  Query: {
+    allEndpoints: () => endpoints,
+    endpoints: (_root, { urls }) => urls.map((url) => endpoints.find(endpoint => endpoint.url === url) || new NotFoundError()),
+  },
+  Mutation: {
+    addEndpoint: async (_root, { url }) => {
+      if (urls.find(u => u === url) === undefined) {
+        urls.push(urls);
+      }
+      await refreshEndpointsAndSchema();
+      return { success: true };
+    },
+    removeEndpoint: async (_root, { url }) => {
+      const index = urls.findIndex(u => u === url);
+      if (index !== undefined) {
+        urls.splice(index, 1);
+      }
+      await refreshEndpointsAndSchema();
+      return { success: true };
+    },
+  },
+}
+
+let urls = [
+  'http://localhost:4001/graphql',
+  'http://localhost:4002/graphql',
+  'http://localhost:4003/graphql',
+  'http://localhost:4004/graphql',
+];
+
+let endpoints;
+let gatewaySchema;
+
+refreshEndpointsAndSchema().then(() => {
+  const app = express();
+  app.use('/graphql', graphqlHTTP(() => ({ schema: gatewaySchema, graphiql: true })));
+  app.listen(4000);
+  console.log('gateway running on port 4000');
+  setTimeout(continueRefreshLoop, 1000);
+});
+
+async function refreshEndpointsAndSchema() {
+  console.log('fetching SDL from services');
+  const sdlPromises = urls.map(url => fetchRemoteSDLOrError(makeRemoteExecutorWithTimeout(url, SDL_TIMEOUT)));
+
+  const sdls = await Promise.all(sdlPromises);
+
+  endpoints = [];
+  sdls.forEach((sdl, index) => {
+    const url = urls[index];
+    if (sdl instanceof Error) {
+      console.log(`Failed to retrieve SDL from "${url}". Received error:\n  ${sdl}`);
+    } else {
+      endpoints.push({
+        url,
+        sdl,
+      });
+      console.log(`added endpoint "${url}"`);
+    }
+  });
+
+  const subschemas = endpoints.map(endpoint => ({
+    schema: buildSchema(endpoint.sdl),
+    executor: makeRemoteExecutorWithTimeout(endpoint.url, OPERATION_TIMEOUT),
+    batching: true,  
+  }));
+
+  console.log('refreshing schema...');
+  gatewaySchema = stitchSchemas({
+    subschemas,
+    typeDefs,
+    resolvers,
+    subschemaConfigTransforms: [stitchingDirectivesTransformer],
+  });
+  console.log('schema refreshed!');
+}
+
+async function continueRefreshLoop() {
+  await refreshEndpointsAndSchema();
+  setTimeout(continueRefreshLoop, 1000);
+}
+
+// Custom fetcher that queries a remote schema for an "sdl" field.
+// This is NOT a standard GraphQL convention – it's just a simple way
+// for a remote API to provide its own schema, complete with custom directives.
+async function fetchRemoteSDLOrError(executor) {
+  const result = await executor({ document: '{ _sdl }' });
+  return result instanceof Error ? result : result.data._sdl;
+}

--- a/06-hot-reloading-with-directives/lib/make_remote_executor_with_timeout.js
+++ b/06-hot-reloading-with-directives/lib/make_remote_executor_with_timeout.js
@@ -1,0 +1,40 @@
+const { fetch } = require('cross-fetch');
+const AbortController = require('abort-controller');
+const { print } = require('graphql');
+
+// Builds a remote schema executor function,
+// customize any way that you need (auth, headers, etc).
+// Expects to recieve an object with "document" and "variable" params,
+// and asynchronously returns a JSON response from the remote.
+module.exports = function makeRemoteExecutorWithTimeout(url, timeout = 500) {
+  return async ({ document, variables }) => {
+    const controller = new AbortController();
+
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, timeout);
+
+    let result;
+
+    try {
+      const query = typeof document === 'string' ? document : print(document);
+      const fetchResult = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+      result = await fetchResult.json();
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        result = new Error(`Response exceeds ${timeout}. Request aborted.`);
+      } else {
+        result = error;
+      }
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    return result;
+  };
+};

--- a/06-hot-reloading-with-directives/lib/not_found_error.js
+++ b/06-hot-reloading-with-directives/lib/not_found_error.js
@@ -1,0 +1,6 @@
+module.exports = class NotFoundError extends Error {
+  constructor(message) {
+    super(message || 'Record not found');
+    this.extensions = { code: 'NOT_FOUND' };
+  }
+};

--- a/06-hot-reloading-with-directives/lib/read_file_sync.js
+++ b/06-hot-reloading-with-directives/lib/read_file_sync.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function readFileSync(dir, filename) {
+  return fs.readFileSync(path.join(dir, filename), 'utf8');
+};

--- a/06-hot-reloading-with-directives/package.json
+++ b/06-hot-reloading-with-directives/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "example01-combining-local-and-remote-schemas",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start-gateway": "nodemon index.js",
+    "start-service-accounts": "nodemon services/accounts/index.js",
+    "start-service-inventory": "nodemon services/inventory/index.js",
+    "start-service-products": "nodemon services/products/index.js",
+    "start-service-reviews": "nodemon services/reviews/index.js",
+    "start-services": "concurrently \"yarn:start-service-*\""
+  },
+  "dependencies": {
+    "@graphql-tools/schema": "^7.0.0",
+    "@graphql-tools/stitch": "^7.0.4",
+    "@graphql-tools/stitching-directives": "^1.0.0",
+    "@graphql-tools/wrap": "^7.0.1",
+    "abort-controller": "^3.0.0",
+    "concurrently": "^5.3.0",
+    "cross-fetch": "^3.0.6",
+    "express": "^4.17.1",
+    "express-graphql": "^0.12.0",
+    "graphql": "^15.4.0",
+    "nodemon": "^2.0.6"
+  }
+}

--- a/06-hot-reloading-with-directives/schema.graphql
+++ b/06-hot-reloading-with-directives/schema.graphql
@@ -1,0 +1,22 @@
+type Endpoint {
+  url: String!
+  sdl: String
+}
+
+type Query {
+  allEndpoints: [Endpoint!]!
+  endpoints(urls: [String!]!): [Endpoint!]!
+}
+
+type AddEndpointPayload {
+  success: Boolean!
+}
+
+type RemoveEndpointPayload {
+  success: Boolean!
+}
+
+type Mutation {
+  addEndpoint(url: String!): AddEndpointPayload!
+  removeEndpoint(url: String!): RemoveEndpointPayload!
+}

--- a/06-hot-reloading-with-directives/services/accounts/index.js
+++ b/06-hot-reloading-with-directives/services/accounts/index.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { graphqlHTTP } = require('express-graphql');
+const schema = require('./schema');
+
+const app = express();
+app.use('/graphql', graphqlHTTP({ schema, graphiql: true }));
+app.listen(4001);

--- a/06-hot-reloading-with-directives/services/accounts/schema.graphql
+++ b/06-hot-reloading-with-directives/services/accounts/schema.graphql
@@ -1,0 +1,13 @@
+type User @key(selectionSet: "{ id }") {
+  id: ID!
+  name: String
+  username: String
+}
+
+scalar _Key
+
+type Query {
+  me: User
+  _users(keys: [_Key!]!): [User] @merge
+  _sdl: String
+}

--- a/06-hot-reloading-with-directives/services/accounts/schema.js
+++ b/06-hot-reloading-with-directives/services/accounts/schema.js
@@ -1,0 +1,39 @@
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
+
+const NotFoundError = require('../../lib/not_found_error');
+const readFileSync = require('../../lib/read_file_sync');
+
+const { stitchingDirectivesTypeDefs, stitchingDirectivesValidator } = stitchingDirectives();
+
+const typeDefs = `
+  ${stitchingDirectivesTypeDefs}
+  ${readFileSync(__dirname, 'schema.graphql')}
+`;
+
+// data fixtures
+const users = [
+  {
+    id: '1',
+    name: 'Ada Lovelace',
+    birthDate: '1815-12-10',
+    username: '@ada'
+  },
+  {
+    id: '2',
+    name: 'Alan Turing',
+    birthDate: '1912-06-23',
+    username: '@complete',
+  },
+];
+
+// graphql resolvers
+const resolvers = {
+  Query: {
+    me: () => users[0],
+    _users: (_root, { keys }) => keys.map((key) => users.find(u => u.id === key.id) || new NotFoundError()),
+    _sdl: () => typeDefs,
+  }
+};
+
+module.exports = makeExecutableSchema({ typeDefs, resolvers, schemaTransforms: [stitchingDirectivesValidator] });

--- a/06-hot-reloading-with-directives/services/inventory/index.js
+++ b/06-hot-reloading-with-directives/services/inventory/index.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { graphqlHTTP } = require('express-graphql');
+const schema = require('./schema');
+
+const app = express();
+app.use('/graphql', graphqlHTTP({ schema, graphiql: true }));
+app.listen(4002);

--- a/06-hot-reloading-with-directives/services/inventory/schema.graphql
+++ b/06-hot-reloading-with-directives/services/inventory/schema.graphql
@@ -1,0 +1,17 @@
+type Product @key(selectionSet: "{ upc }") {
+  upc: String!
+  inStock: Boolean
+  shippingEstimate: Int @computed(selectionSet: "{ price weight }")
+}
+
+input ProductKey {
+  upc: String!
+  price: Int
+  weight: Int
+}
+
+type Query {
+  mostStockedProduct: Product
+  _products(keys: [ProductKey!]!): [Product]! @merge
+  _sdl: String
+}

--- a/06-hot-reloading-with-directives/services/inventory/schema.js
+++ b/06-hot-reloading-with-directives/services/inventory/schema.js
@@ -1,0 +1,40 @@
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
+
+const NotFoundError = require('../../lib/not_found_error');
+const readFileSync = require('../../lib/read_file_sync');
+
+const { stitchingDirectivesTypeDefs, stitchingDirectivesValidator } = stitchingDirectives();
+
+const typeDefs = `
+  ${stitchingDirectivesTypeDefs}
+  ${readFileSync(__dirname, 'schema.graphql')}
+`;
+
+// data fixtures
+const inventory = [
+  { upc: '1', inStock: true },
+  { upc: '2', inStock: false },
+  { upc: '3', inStock: true }
+];
+
+// graphql resolvers
+const resolvers = {
+  Product: {
+    shippingEstimate: product => {
+      if (product.price > 1000) {
+        return 0 // free for expensive items
+      }
+      return Math.round(product.weight * 0.5) || null; // estimate is based on weight
+    }
+  },
+  Query: {
+    mostStockedProduct: () => inventory.find(i => i.upc === '3'),
+    _products: (_root, { keys }) => {
+      return keys.map(key => ({ ...key, ...inventory.find(i => i.upc === key.upc) || new NotFoundError() }));
+    },
+    _sdl: () => typeDefs,
+  },
+};
+
+module.exports = makeExecutableSchema({ typeDefs, resolvers, schemaTransforms: [stitchingDirectivesValidator] });

--- a/06-hot-reloading-with-directives/services/products/index.js
+++ b/06-hot-reloading-with-directives/services/products/index.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { graphqlHTTP } = require('express-graphql');
+const schema = require('./schema');
+
+const app = express();
+app.use('/graphql', graphqlHTTP({ schema, graphiql: true }));
+app.listen(4003);

--- a/06-hot-reloading-with-directives/services/products/schema.graphql
+++ b/06-hot-reloading-with-directives/services/products/schema.graphql
@@ -1,0 +1,12 @@
+type Product @key(selectionSet: "{ upc }") {
+  upc: String!
+  name: String
+  price: Int
+  weight: Int
+}
+
+type Query {
+  topProducts(first: Int = 2): [Product]
+  _productsByUpc(upcs: [String!]!): [Product] @merge(keyField: "upc")
+  _sdl: String
+}

--- a/06-hot-reloading-with-directives/services/products/schema.js
+++ b/06-hot-reloading-with-directives/services/products/schema.js
@@ -1,0 +1,45 @@
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
+
+const NotFoundError = require('../../lib/not_found_error');
+const readFileSync = require('../../lib/read_file_sync');
+
+const { stitchingDirectivesTypeDefs, stitchingDirectivesValidator } = stitchingDirectives();
+
+const typeDefs = `
+  ${stitchingDirectivesTypeDefs}
+  ${readFileSync(__dirname, 'schema.graphql')}
+`;
+
+// data fixtures
+const products = [
+  {
+    upc: '1',
+    name: 'Table',
+    price: 899,
+    weight: 100
+  },
+  {
+    upc: '2',
+    name: 'Couch',
+    price: 1299,
+    weight: 1000
+  },
+  {
+    upc: '3',
+    name: 'Chair',
+    price: 54,
+    weight: 50
+  }
+];
+
+// graphql resolvers
+const resolvers = {
+  Query: {
+    topProducts: (_root, args) => products.slice(0, args.first),
+    _productsByUpc: (_root, { upcs }) => upcs.map((upc) => products.find(product => product.upc === upc) || NotFoundError),
+    _sdl: () => typeDefs,
+  },
+};
+
+module.exports = makeExecutableSchema({ typeDefs, resolvers, schemaTransforms: [stitchingDirectivesValidator] });

--- a/06-hot-reloading-with-directives/services/reviews/index.js
+++ b/06-hot-reloading-with-directives/services/reviews/index.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { graphqlHTTP } = require('express-graphql');
+const schema = require('./schema');
+
+const app = express();
+app.use('/graphql', graphqlHTTP({ schema, graphiql: true }));
+app.listen(4004);

--- a/06-hot-reloading-with-directives/services/reviews/schema.graphql
+++ b/06-hot-reloading-with-directives/services/reviews/schema.graphql
@@ -1,0 +1,37 @@
+type Review {
+  id: ID!
+  body: String
+  author: User
+  product: Product
+}
+
+type User @key(selectionSet: "{ id }") {
+  id: ID!
+  username: String
+  numberOfReviews: Int
+  reviews: [Review]
+}
+
+type Product @key(selectionSet: "{ upc }") {
+  upc: String!
+  reviews: [Review]
+}
+
+input UserKey {
+  id: ID!
+}
+
+input ProductKey {
+  upc: String!
+}
+
+input ProductInput {
+  keys: [ProductKey!]!
+}
+
+type Query {
+  _reviews(id: ID!): Review
+  _users(keys: [UserKey!]!): [User] @merge
+  _products(input: ProductInput): [Product]! @merge(keyArg: "input.keys")
+  _sdl: String
+}

--- a/06-hot-reloading-with-directives/services/reviews/schema.js
+++ b/06-hot-reloading-with-directives/services/reviews/schema.js
@@ -1,0 +1,68 @@
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
+
+const NotFoundError = require('../../lib/not_found_error');
+const readFileSync = require('../../lib/read_file_sync');
+
+const { stitchingDirectivesTypeDefs, stitchingDirectivesValidator } = stitchingDirectives();
+
+const typeDefs = `
+  ${stitchingDirectivesTypeDefs}
+  ${readFileSync(__dirname, 'schema.graphql')}
+`;
+
+// data fixtures
+const usernames = [
+  { id: '1', username: '@ada' },
+  { id: '2', username: '@complete' },
+];
+
+const reviews = [
+  {
+    id: '1',
+    authorId: '1',
+    product: { upc: '1' },
+    body: 'Love it!',
+  },
+  {
+    id: '2',
+    authorId: '1',
+    product: { upc: '2' },
+    body: 'Too expensive.',
+  },
+  {
+    id: '3',
+    authorId: '2',
+    product: { upc: '3' },
+    body: 'Could be better.',
+  },
+  {
+    id: '4',
+    authorId: '2',
+    product: { upc: '1' },
+    body: 'Prefer something else.',
+  },
+];
+
+// graphql resolvers
+const resolvers = {
+  Review: {
+    author: (review) => ({ __typename: 'User', id: review.authorId }),
+  },
+  User: {
+    reviews: (user) => reviews.filter(review => review.authorId === user.id),
+    numberOfReviews: (user) => reviews.filter(review => review.authorId === user.id).length,
+    username: (user) => usernames.find(username => username.id === user.id) || NotFoundError,
+  },
+  Product: {
+    reviews: (product) => reviews.filter(review => review.product.upc === product.upc),
+  },
+  Query: {
+    _reviews: (_root, { id }) => reviews.find(review => review.id === id) || NotFoundError,
+    _users: (_root, { keys }) => keys,
+    _products: (_root, { input }) => input.keys,
+    _sdl: () => typeDefs,
+  },
+};
+
+module.exports = makeExecutableSchema({ typeDefs, resolvers, schemaTransforms: [stitchingDirectivesValidator] });

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Self-guided examples of [Schema Stitching](https://www.graphql-tools.com/docs/st
   - Adding a remote subscription service.
   - Adding a subscriber proxy.
 
+- **Example 6 - [Hot reloading with stitching directives](./06-hot-reloading-with-stitching-directives)**
+
+  - Adding remote schemas, with typedefs and custom directives exposed via a custom root field.
+  - Use of the @key, @computed and @merge directives to specify type merging configuration.
+  - Use of a custom executor that times out a request after a pre-specified limit.
+  - Addition of custom queries/mutations on the gateway for listing/modifying the configured services.
+  - Hot reloading of the gateway schema based on "push" input of service changes and "pull" input of service health.
+
 - **Appendices**
 
   - [What is Array Batching?](https://github.com/gmac/schema-stitching-demos/wiki/Batching-Arrays-and-Queries#what-is-array-batching)


### PR DESCRIPTION
This example includes a gateway supporting hot-reloading via both "push" and "pull" notifications of schema health.

Service specific merge configuration is stored inside the schema sdl with directives.