### PR TITLE
Simplify merge directive patterns

### DIFF
--- a/continuous-integration-testing/package.json
+++ b/continuous-integration-testing/package.json
@@ -8,8 +8,8 @@
     "test": "jest test"
   },
   "dependencies": {
-    "@graphql-tools/stitch": "^7.0.4",
-    "@graphql-tools/stitching-directives": "^1.0.0",
+    "@graphql-tools/stitch": "^7.1.8",
+    "@graphql-tools/stitching-directives": "^1.1.2",
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",

--- a/continuous-integration-testing/remote_schemas/products.graphql
+++ b/continuous-integration-testing/remote_schemas/products.graphql
@@ -2,7 +2,7 @@ directive @key(selectionSet: String!) on OBJECT
 directive @merge(keyField: String, keyArg: String, additionalArgs: String, key: [String!], argsExpr: String) on FIELD_DEFINITION
 directive @computed(selectionSet: String!) on FIELD_DEFINITION
 
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   name: String!
   price: Int!

--- a/continuous-integration-testing/remote_schemas/reviews.graphql
+++ b/continuous-integration-testing/remote_schemas/reviews.graphql
@@ -9,13 +9,13 @@ type Review {
   product: Product
 }
 
-type User @key(selectionSet: "{ id }") {
+type User {
   id: ID!
   totalReviews: Int!
   reviews: [Review]
 }
 
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   reviews: [Review]
 }

--- a/continuous-integration-testing/remote_schemas/users.graphql
+++ b/continuous-integration-testing/remote_schemas/users.graphql
@@ -2,7 +2,7 @@ directive @key(selectionSet: String!) on OBJECT
 directive @merge(keyField: String, keyArg: String, additionalArgs: String, key: [String!], argsExpr: String) on FIELD_DEFINITION
 directive @computed(selectionSet: String!) on FIELD_DEFINITION
 
-type User @key(selectionSet: "{ id }") {
+type User {
   id: ID!
   name: String!
   username: String!

--- a/curating-descriptions-and-fields/package.json
+++ b/curating-descriptions-and-fields/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
-    "@graphql-tools/stitch": "^7.0.4",
-    "@graphql-tools/stitching-directives": "^1.0.0",
+    "@graphql-tools/stitch": "^7.1.8",
+    "@graphql-tools/stitching-directives": "^1.1.2",
     "@graphql-tools/utils": "^7.2.0",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",

--- a/curating-descriptions-and-fields/services/accounts/schema.graphql
+++ b/curating-descriptions-and-fields/services/accounts/schema.graphql
@@ -1,5 +1,5 @@
 "Represents a human user with an account."
-type User @key(selectionSet: "{ id }") {
+type User {
   "The primary key of this user."
   id: ID!
   "A formal display name for this user."

--- a/curating-descriptions-and-fields/services/products/schema.graphql
+++ b/curating-descriptions-and-fields/services/products/schema.graphql
@@ -1,5 +1,5 @@
 "Represents a retail product."
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   "The Univeral Product Code (UPC) of this product."
   upc: ID!
   "The name of this product."

--- a/curating-descriptions-and-fields/services/reviews/schema.graphql
+++ b/curating-descriptions-and-fields/services/reviews/schema.graphql
@@ -11,7 +11,7 @@ type Review {
 }
 
 # IGNORE - documented in Accounts service
-type User @key(selectionSet: "{ id }") {
+type User {
   # IGNORE - documented in Accounts service
   id: ID!
   "Reviews written by this user."
@@ -19,7 +19,7 @@ type User @key(selectionSet: "{ id }") {
 }
 
 # IGNORE - documented in Products service
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   # IGNORE - documented in Products service
   upc: ID!
   "Reviews written about this product."

--- a/federation-services/README.md
+++ b/federation-services/README.md
@@ -4,7 +4,7 @@ This example demonstrates the integration of [Apollo Federation services](https:
 
 As you get the hang of schema stitching, you may realize that Federation services are fairly complex for what they do. The `buildFederatedSchema` method from the `@apollo/federation` package creates a nuanced GraphQL resource that does not guarentee itself to be independently consistent or valid, but plugs seamlessly into a greater automation package. By comparison, stitching encourages services to be independently valid and self-contained GraphQL resources, which makes them quite primitive and durable. While federation automates service bindings at the cost of tightly-coupled complexity, stitching embraces loosely-coupled bindings at the cost of manual setup. The merits of each strategy are likely to be a deciding factor for developers selecting a platform. Stitching is a _library_ used to build a _framework_ like Federation.
 
-Stitching is less opinionated than Federation, and is simpler to use without the complexity added by `buildFederatedSchema`. However, when integrating with existing servers or in the process of a migration, nothing says you can't incorporate your existing federation resources into a stitched gateway.
+Stitching is less opinionated than Federation, and is simpler without the complexity added by `buildFederatedSchema`. However, when integrating with existing servers or in the process of a migration, nothing says you can't incorporate your existing federation resources into a stitched gateway.
 
 **This example demonstrates:**
 

--- a/hot-schema-reloading/package.json
+++ b/hot-schema-reloading/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
-    "@graphql-tools/stitch": "^7.0.4",
-    "@graphql-tools/stitching-directives": "^1.0.0",
+    "@graphql-tools/stitch": "^7.1.8",
+    "@graphql-tools/stitching-directives": "^1.1.2",
     "abort-controller": "^3.0.0",
     "concurrently": "^5.3.0",
     "cross-fetch": "^3.0.6",

--- a/hot-schema-reloading/services/inventory/schema.graphql
+++ b/hot-schema-reloading/services/inventory/schema.graphql
@@ -1,16 +1,10 @@
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   inStock: Boolean
 }
 
-input ProductKey {
-  upc: ID!
-  price: Int
-  weight: Int
-}
-
 type Query {
   mostStockedProduct: Product
-  _products(keys: [ProductKey!]!): [Product]! @merge
+  _products(upcs: [ID!]!): [Product]! @merge(keyField: "upc")
   _sdl: String!
 }

--- a/hot-schema-reloading/services/inventory/schema.js
+++ b/hot-schema-reloading/services/inventory/schema.js
@@ -25,9 +25,7 @@ module.exports = makeExecutableSchema({
     },
     Query: {
       mostStockedProduct: () => inventory.reduce((acc, i) => acc.unitsInStock >= i.unitsInStock ? acc : i, inventory[0]),
-      _products: (_root, { keys }) => {
-        return keys.map(key => ({ ...key, ...inventory.find(i => i.upc === key.upc) || new NotFoundError() }));
-      },
+      _products: (_root, { upcs }) => upcs.map(upc => inventory.find(i => i.upc === upc) || new NotFoundError()),
       _sdl: () => typeDefs,
     },
   }

--- a/hot-schema-reloading/services/products/schema.graphql
+++ b/hot-schema-reloading/services/products/schema.graphql
@@ -1,4 +1,4 @@
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   name: String!
   price: Int!

--- a/stitching-directives-sdl/README.md
+++ b/stitching-directives-sdl/README.md
@@ -70,7 +70,7 @@ Neat, it works! All those merges were configured through schema SDL annotations.
 Open the Accounts schema and see the expression of a [single-record merge query](../type-merging-single-records):
 
 ```graphql
-type User @key(selectionSet: "{ id }") {
+type User {
   id: ID!
   name: String!
   username: String!
@@ -93,14 +93,14 @@ merge: {
 }
 ```
 
-Here the `@key` directive specifies a base selection set for the merged type, and the `@merge(keyField: "id")` directive marks a merger query&mdash;specifying that the `id` field should be picked from the original object as the query argument.
+Here the `@merge(keyField: "id")` directive marks a merger query, and specifies that the `id` field acts as a selectionSet to be fetched with the original object and picked as the query argument.
 
 ### Picked keys with additional arguments
 
 Next, open the Products schema and see the expression of an [array-batched merge query](../type-merging-arrays):
 
 ```graphql
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
 }
 
@@ -126,7 +126,7 @@ merge: {
 }
 ```
 
-Again, the `@key` directive specifies a base selection set for the merged type, and the `@merge(keyField: "upc")` directive marks a merger array query&mdash;specifying that a `upc` field should be picked from each original object for the query argument array.
+Again, the `@merge(keyField: "upc")` directive marks a merger array query, and specifies that the `upc` field acts as a selectionSet to be fetched with each original object and picked into the query argument array. The `keyArg` argument specifies which query argument receives the array of keys, and `additionalArgs` specifies static values to provide for other arguments.
 
 ### Object keys
 

--- a/stitching-directives-sdl/package.json
+++ b/stitching-directives-sdl/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
-    "@graphql-tools/stitch": "^7.0.4",
-    "@graphql-tools/stitching-directives": "^1.0.0",
+    "@graphql-tools/stitch": "^7.1.8",
+    "@graphql-tools/stitching-directives": "^1.1.2",
     "concurrently": "^5.3.0",
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",

--- a/stitching-directives-sdl/services/accounts/schema.graphql
+++ b/stitching-directives-sdl/services/accounts/schema.graphql
@@ -1,4 +1,4 @@
-type User @key(selectionSet: "{ id }") {
+type User {
   id: ID!
   name: String!
   username: String!

--- a/stitching-directives-sdl/services/products/schema.graphql
+++ b/stitching-directives-sdl/services/products/schema.graphql
@@ -1,4 +1,4 @@
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   name: String!
   price: Int!

--- a/versioning-schema-releases/package.json
+++ b/versioning-schema-releases/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
-    "@graphql-tools/stitch": "^7.0.4",
-    "@graphql-tools/stitching-directives": "^1.0.0",
+    "@graphql-tools/stitch": "^7.1.8",
+    "@graphql-tools/stitching-directives": "^1.1.2",
     "abort-controller": "^3.0.0",
     "concurrently": "^5.3.0",
     "cross-fetch": "^3.0.6",

--- a/versioning-schema-releases/services/inventory/schema.graphql
+++ b/versioning-schema-releases/services/inventory/schema.graphql
@@ -1,16 +1,10 @@
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   inStock: Boolean
 }
 
-input ProductKey {
-  upc: ID!
-  price: Int
-  weight: Int
-}
-
 type Query {
   mostStockedProduct: Product
-  _products(keys: [ProductKey!]!): [Product]! @merge
+  _products(upcs: [ID!]!): [Product]! @merge(keyField: "upc")
   _sdl: String!
 }

--- a/versioning-schema-releases/services/inventory/schema.js
+++ b/versioning-schema-releases/services/inventory/schema.js
@@ -25,9 +25,7 @@ module.exports = makeExecutableSchema({
     },
     Query: {
       mostStockedProduct: () => inventory.reduce((acc, i) => acc.unitsInStock >= i.unitsInStock ? acc : i, inventory[0]),
-      _products: (_root, { keys }) => {
-        return keys.map(key => ({ ...key, ...inventory.find(i => i.upc === key.upc) || new NotFoundError() }));
-      },
+      _products: (_root, { upcs }) => upcs.map(upc => inventory.find(i => i.upc === upc) || new NotFoundError()),
       _sdl: () => typeDefs,
     },
   }

--- a/versioning-schema-releases/services/products/schema.graphql
+++ b/versioning-schema-releases/services/products/schema.graphql
@@ -1,4 +1,4 @@
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   upc: ID!
   name: String!
   price: Int!


### PR DESCRIPTION
Updates several examples to reflect the simplified `@merge` directive pattern introduced in https://github.com/ardatan/graphql-tools/commit/6e50d9fca1dfb8586515d176990a7313cc8e2055.

TL;DR – this update allows `@merge(keyField: "id")` to automatically infer a `selectionSet` for the associated merge type, therefore the `@key` directive is no longer required in conjunction with the `keyField` merge argument.