### PR TITLE
Orchestrate TCP connections using wait-on

### DIFF
--- a/combining-local-and-remote-schemas/README.md
+++ b/combining-local-and-remote-schemas/README.md
@@ -20,13 +20,7 @@ This example explores basic techniques for combining local and remote schemas to
 cd combining-local-and-remote-schemas
 
 yarn install
-yarn start-services
-```
-
-Then in a new terminal tab:
-
-```shell
-yarn start-gateway
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/combining-local-and-remote-schemas/index.js
+++ b/combining-local-and-remote-schemas/index.js
@@ -1,3 +1,4 @@
+const waitOn = require('wait-on');
 const express = require('express');
 const { graphqlHTTP } = require('express-graphql');
 const { introspectSchema, RenameTypes, RenameRootFields } = require('@graphql-tools/wrap');
@@ -73,8 +74,8 @@ async function fetchRemoteSDL(executor) {
   return result.data._sdl;
 }
 
-makeGatewaySchema().then(schema => {
+waitOn({ resources: ['tcp:4001', 'tcp:4002'] }, async () => {
   const app = express();
-  app.use('/graphql', graphqlHTTP({ schema, graphiql: true }));
+  app.use('/graphql', graphqlHTTP({ schema: await makeGatewaySchema(), graphiql: true }));
   app.listen(4000, () => console.log('gateway running at http://localhost:4000/graphql'));
 });

--- a/combining-local-and-remote-schemas/package.json
+++ b/combining-local-and-remote-schemas/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "start-products": "nodemon --watch services/products services/products/index.js",
+    "start-storefronts": "nodemon --watch services/storefronts services/storefronts/index.js",
     "start-gateway": "nodemon index.js",
-    "start-service-products": "nodemon services/products/index.js",
-    "start-service-storefronts": "nodemon services/storefronts/index.js",
-    "start-services": "concurrently \"yarn:start-service-*\""
+    "start": "concurrently \"yarn:start-*\""
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
@@ -18,6 +18,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "graphql": "^15.4.0",
-    "nodemon": "^2.0.6"
+    "nodemon": "^2.0.6",
+    "wait-on": "^5.2.1"
   }
 }

--- a/computed-fields/README.md
+++ b/computed-fields/README.md
@@ -30,7 +30,7 @@ However, computed fields have several distinct disadvantages:
 cd computed-fields
 
 yarn install
-yarn start-gateway
+yarn start
 ```
 
 The following service is available for interactive queries:

--- a/computed-fields/package.json
+++ b/computed-fields/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-gateway": "nodemon index.js"
+    "start": "nodemon index.js"
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",

--- a/continuous-integration-testing/package.json
+++ b/continuous-integration-testing/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-gateway": "node index.js",
+    "start": "node index.js",
     "test": "jest test"
   },
   "dependencies": {

--- a/curating-descriptions-and-fields/README.md
+++ b/curating-descriptions-and-fields/README.md
@@ -14,7 +14,7 @@ This example demonstrates curating element descriptions and public fields to ens
 cd curating-descriptions-and-fields
 
 yarn install
-yarn start-gateway
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/curating-descriptions-and-fields/package.json
+++ b/curating-descriptions-and-fields/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-gateway": "nodemon -e js,graphql index.js"
+    "start": "nodemon -e js,graphql index.js"
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",

--- a/federation-services/README.md
+++ b/federation-services/README.md
@@ -17,13 +17,7 @@ Stitching is less opinionated than Federation, and is simpler without the comple
 cd federation-services
 
 yarn install
-yarn start-services
-```
-
-Then in a new terminal tab:
-
-```shell
-yarn start-gateway
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/federation-services/index.js
+++ b/federation-services/index.js
@@ -1,3 +1,4 @@
+const waitOn = require('wait-on');
 const { stitchSchemas } = require('@graphql-tools/stitch');
 const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
 const { stitchingDirectivesTransformer } = stitchingDirectives();
@@ -26,4 +27,6 @@ async function fetchFederationSubchema(executor) {
   };
 }
 
-makeGatewaySchema().then(schema => makeServer(schema, 'gateway', 4000));
+waitOn({ resources: [4001, 4002, 4003].map(p => `tcp:${p}`) }, async () => {
+  makeServer(await makeGatewaySchema(), 'gateway', 4000);
+});

--- a/federation-services/package.json
+++ b/federation-services/package.json
@@ -4,11 +4,11 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-gateway": "nodemon index.js",
-    "start-service-products": "node services/products/index.js",
-    "start-service-reviews": "node services/reviews/index.js",
-    "start-service-users": "node services/users/index.js",
-    "start-services": "concurrently \"yarn:start-service-*\""
+    "start-products": "nodemon -e js,graphql --watch services/products services/products/index.js",
+    "start-reviews": "nodemon -e js,graphql --watch services/reviews services/reviews/index.js",
+    "start-users": "nodemon -e js,graphql --watch services/users services/users/index.js",
+    "start-gateway": "nodemon -e js,graphql index.js",
+    "start": "concurrently \"yarn:start-*\""
   },
   "dependencies": {
     "@apollo/federation": "^0.20.6",
@@ -20,6 +20,7 @@
     "express-graphql": "^0.12.0",
     "federation-to-stitching-sdl": "^1.0.0",
     "graphql": "^15.4.0",
-    "nodemon": "^2.0.6"
+    "nodemon": "^2.0.6",
+    "wait-on": "^5.2.1"
   }
 }

--- a/mutations-and-subscriptions/README.md
+++ b/mutations-and-subscriptions/README.md
@@ -14,13 +14,7 @@ This example explores stitching mutation and subscription services into a combin
 cd mutations-and-subscriptions
 
 yarn install
-yarn start-services
-```
-
-Then in a new terminal tab:
-
-```shell
-yarn start-gateway
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/mutations-and-subscriptions/index.js
+++ b/mutations-and-subscriptions/index.js
@@ -1,3 +1,4 @@
+const waitOn = require('wait-on');
 const { ApolloServer } = require('apollo-server');
 const { introspectSchema } = require('@graphql-tools/wrap');
 const { stitchSchemas } = require('@graphql-tools/stitch');
@@ -37,7 +38,8 @@ async function makeGatewaySchema() {
   });
 }
 
-makeGatewaySchema().then(schema => {
+waitOn({ resources: ['tcp:4001', 'tcp:4002'] }, async () => {
+  const schema = await makeGatewaySchema();
   const server = new ApolloServer({ schema }); // uses Apollo Server for its subscription UI features
   server.listen(4000).then(() => console.log(`gateway running at http://localhost:4000/graphql`));
 });

--- a/mutations-and-subscriptions/package.json
+++ b/mutations-and-subscriptions/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "start-posts": "nodemon --watch services/posts services/posts/index.js",
+    "start-users": "nodemon --watch services/users services/users/index.js",
     "start-gateway": "nodemon index.js",
-    "start-service-posts": "nodemon services/posts/index.js",
-    "start-service-users": "nodemon services/users/index.js",
-    "start-services": "concurrently \"yarn:start-service-*\""
+    "start": "concurrently \"yarn:start-*\""
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.1.0",
@@ -21,6 +21,7 @@
     "graphql": "^15.4.0",
     "graphql-ws": "^2.0.0",
     "nodemon": "^2.0.6",
+    "wait-on": "^5.2.1",
     "ws": "^7.4.0"
   }
 }

--- a/stitching-directives-sdl/README.md
+++ b/stitching-directives-sdl/README.md
@@ -23,7 +23,7 @@ Note: the service setup in this example is based on the [official demonstration 
 cd stitching-directives-sdl
 
 yarn install
-yarn start-services
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/stitching-directives-sdl/package.json
+++ b/stitching-directives-sdl/package.json
@@ -1,15 +1,15 @@
 {
   "name": "stitching-directives-sdl",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-service-accounts": "nodemon -e js,graphql services/accounts/index.js",
-    "start-service-inventory": "nodemon -e js,graphql services/inventory/index.js",
-    "start-service-products": "nodemon -e js,graphql services/products/index.js",
-    "start-service-reviews": "nodemon -e js,graphql services/reviews/index.js",
-    "start-service-gateway": "nodemon -e js,graphql index.js",
-    "start-services": "concurrently \"yarn:start-service-*\""
+    "start-accounts": "nodemon -e js,graphql --watch services/accounts services/accounts/index.js",
+    "start-inventory": "nodemon -e js,graphql --watch services/inventory services/inventory/index.js",
+    "start-products": "nodemon -e js,graphql --watch services/products services/products/index.js",
+    "start-reviews": "nodemon -e js,graphql --watch services/reviews services/reviews/index.js",
+    "start-gateway": "nodemon -e js,graphql index.js",
+    "start": "concurrently \"yarn:start-*\""
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
@@ -20,6 +20,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "graphql": "^15.4.0",
-    "nodemon": "^2.0.6"
+    "nodemon": "^2.0.6",
+    "wait-on": "^5.2.1"
   }
 }

--- a/type-merging-arrays/README.md
+++ b/type-merging-arrays/README.md
@@ -26,13 +26,7 @@ This example focuses on [array batching](https://github.com/gmac/schema-stitchin
 cd type-merging-arrays
 
 yarn install
-yarn start-services
-```
-
-Then in a new terminal tab:
-
-```shell
-yarn start-gateway
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/type-merging-arrays/index.js
+++ b/type-merging-arrays/index.js
@@ -1,3 +1,4 @@
+const waitOn = require('wait-on');
 const { stitchSchemas } = require('@graphql-tools/stitch');
 const { introspectSchema } = require('@graphql-tools/wrap');
 const makeServer = require('./lib/make_server');
@@ -69,4 +70,6 @@ async function makeGatewaySchema() {
   });
 }
 
-makeGatewaySchema().then(schema => makeServer(schema, 'gateway', 4000));
+waitOn({ resources: ['tcp:4001', 'tcp:4002', 'tcp:4003'] }, async () => {
+  makeServer(await makeGatewaySchema(), 'gateway', 4000);
+});

--- a/type-merging-arrays/package.json
+++ b/type-merging-arrays/package.json
@@ -4,11 +4,11 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "start-manufacturers": "nodemon --watch services/manufacturers services/manufacturers/index.js",
+    "start-products": "nodemon --watch services/products services/products/index.js",
+    "start-storefronts": "nodemon --watch services/storefronts services/storefronts/index.js",
     "start-gateway": "nodemon index.js",
-    "start-service-manufacturers": "node services/manufacturers/index.js",
-    "start-service-products": "node services/products/index.js",
-    "start-service-storefronts": "node services/storefronts/index.js",
-    "start-services": "concurrently \"yarn:start-service-*\""
+    "start": "concurrently \"yarn:start-*\""
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
@@ -19,6 +19,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "graphql": "^15.4.0",
-    "nodemon": "^2.0.6"
+    "nodemon": "^2.0.6",
+    "wait-on": "^5.2.1"
   }
 }

--- a/type-merging-interfaces/README.md
+++ b/type-merging-interfaces/README.md
@@ -16,7 +16,7 @@ This example explores setting up a GraphQL interface that spans across service b
 cd cross-service-interfaces
 
 yarn install
-yarn start-gateway
+yarn start
 ```
 
 The following service is available for interactive queries:

--- a/type-merging-interfaces/package.json
+++ b/type-merging-interfaces/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-gateway": "nodemon index.js"
+    "start": "nodemon index.js"
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",

--- a/type-merging-nullables/README.md
+++ b/type-merging-nullables/README.md
@@ -13,7 +13,7 @@ This example demonstrates using nullable and not-null fields in merged data, as 
 cd type-merging-nullables
 
 yarn install
-yarn start-gateway
+yarn start
 ```
 
 The following service is available for interactive queries:

--- a/type-merging-nullables/package.json
+++ b/type-merging-nullables/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start-gateway": "nodemon index.js"
+    "start": "nodemon index.js"
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",

--- a/type-merging-single-records/README.md
+++ b/type-merging-single-records/README.md
@@ -25,13 +25,7 @@ Using single-record queries means that every record accessed requires a _dedicat
 cd type-merging-single-records
 
 yarn install
-yarn start-services
-```
-
-Then in a new terminal tab:
-
-```shell
-yarn start-gateway
+yarn start
 ```
 
 The following services are available for interactive queries:

--- a/type-merging-single-records/index.js
+++ b/type-merging-single-records/index.js
@@ -1,3 +1,4 @@
+const waitOn = require('wait-on');
 const { stitchSchemas } = require('@graphql-tools/stitch');
 const { introspectSchema } = require('@graphql-tools/wrap');
 const makeServer = require('./lib/make_server');
@@ -67,4 +68,6 @@ async function makeGatewaySchema() {
   });
 }
 
-makeGatewaySchema().then(schema => makeServer(schema, 'gateway', 4000));
+waitOn({ resources: ['tcp:4001', 'tcp:4002', 'tcp:4003'] }, async () => {
+  makeServer(await makeGatewaySchema(), 'gateway', 4000);
+});

--- a/type-merging-single-records/package.json
+++ b/type-merging-single-records/package.json
@@ -4,11 +4,11 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "start-manufacturers": "nodemon --watch services/manufacturers services/manufacturers/index.js",
+    "start-products": "nodemon --watch services/products services/products/index.js",
+    "start-storefronts": "nodemon --watch services/storefronts services/storefronts/index.js",
     "start-gateway": "nodemon index.js",
-    "start-service-manufacturers": "node services/manufacturers/index.js",
-    "start-service-products": "node services/products/index.js",
-    "start-service-storefronts": "node services/storefronts/index.js",
-    "start-services": "concurrently \"yarn:start-service-*\""
+    "start": "concurrently \"yarn:start-*\""
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
@@ -19,6 +19,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "graphql": "^15.4.0",
-    "nodemon": "^2.0.6"
+    "nodemon": "^2.0.6",
+    "wait-on": "^5.2.1"
   }
 }


### PR DESCRIPTION
Courtesy of the tip from @orefalo, adds the `wait-on` package to most of the foundation examples so that all services and the gateway can reliably run/restarted together in a single process without port races. Huge improvement to the later examples that start using port retries (still have a few to update).

Also cleans up nodemon parameterization so that watches only restart in response to changes in their respective subservices.