### PR TITLE
Add a canonical directive to SDL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Guided examples of [Schema Stitching](https://www.graphql-tools.com/docs/stitch-
   - `@key` directive for type-level selection sets.
   - `@merge` directive for type merging services.
   - `@computed` directive for computed fields.
+  - `@canonical` directive for preferred element definitions.
 
 ### Architecture
 

--- a/stitching-directives-sdl/README.md
+++ b/stitching-directives-sdl/README.md
@@ -16,6 +16,7 @@ Note: the service setup in this example is based on the [official demonstration 
 - `@key` directive for type-level selection sets.
 - `@merge` directive for type merging services.
 - `@computed` directive for computed fields.
+- `@canonical` directive for preferred element definitions.
 
 ## Setup
 

--- a/stitching-directives-sdl/README.md
+++ b/stitching-directives-sdl/README.md
@@ -243,6 +243,19 @@ type Query {
 }
 ```
 
+### Canonical definitions
+
+Open the documentation sidebar of GraphiQL for the gateway schema, and have a look at the `Product` type definition. While this type is defined in three different ways by three different services, you'll see that element descriptions from the Products subschema are favored in the combined gateway schema because it is marked as `@canonical`:
+
+```
+"Represents a Product available for resale."
+type Product @canonical {
+  # ...
+}
+```
+
+Types marked as canonical will provide a preferred definition of the type and its fields to the combined gateway schema. That means we can write clean descriptions for a type and its fields in one service, and expect those definitions to be used in the combined gateway schema. Specific fields may also be marked as canonical to override a canonical type definition. Fields that are unique to a given subservice have no competing definitions, and are therefore canonical by default.
+
 ### For demonstration only!
 
 This example uses several needlessly complex key patterns for the sake of demonstration. For simplicity, it's generally best to use the basic picked key patterns whenever possible. Sending object keys is generally only necessary when implementing computed fields or communicating with federation services.

--- a/stitching-directives-sdl/index.js
+++ b/stitching-directives-sdl/index.js
@@ -1,7 +1,7 @@
 const waitOn = require('wait-on');
 const { stitchSchemas } = require('@graphql-tools/stitch');
 const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
-const { buildSchema, printSchema } = require('graphql');
+const { buildSchema } = require('graphql');
 const makeServer = require('./lib/make_server');
 const makeRemoteExecutor = require('./lib/make_remote_executor');
 
@@ -9,8 +9,8 @@ const { stitchingDirectivesTransformer } = stitchingDirectives();
 
 async function makeGatewaySchema() {
   const accountsExec = makeRemoteExecutor('http://localhost:4001/graphql');
-  const productsExec = makeRemoteExecutor('http://localhost:4003/graphql');
   const inventoryExec = makeRemoteExecutor('http://localhost:4002/graphql');
+  const productsExec = makeRemoteExecutor('http://localhost:4003/graphql');
   const reviewsExec = makeRemoteExecutor('http://localhost:4004/graphql');
 
   return stitchSchemas({

--- a/stitching-directives-sdl/index.js
+++ b/stitching-directives-sdl/index.js
@@ -1,7 +1,7 @@
 const waitOn = require('wait-on');
 const { stitchSchemas } = require('@graphql-tools/stitch');
 const { stitchingDirectives } = require('@graphql-tools/stitching-directives');
-const { buildSchema } = require('graphql');
+const { buildSchema, printSchema } = require('graphql');
 const makeServer = require('./lib/make_server');
 const makeRemoteExecutor = require('./lib/make_remote_executor');
 
@@ -9,8 +9,8 @@ const { stitchingDirectivesTransformer } = stitchingDirectives();
 
 async function makeGatewaySchema() {
   const accountsExec = makeRemoteExecutor('http://localhost:4001/graphql');
-  const inventoryExec = makeRemoteExecutor('http://localhost:4002/graphql');
   const productsExec = makeRemoteExecutor('http://localhost:4003/graphql');
+  const inventoryExec = makeRemoteExecutor('http://localhost:4002/graphql');
   const reviewsExec = makeRemoteExecutor('http://localhost:4004/graphql');
 
   return stitchSchemas({

--- a/stitching-directives-sdl/package.json
+++ b/stitching-directives-sdl/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
-    "@graphql-tools/stitch": "^7.1.8",
-    "@graphql-tools/stitching-directives": "^1.1.2",
+    "@graphql-tools/stitch": "^7.2.1",
+    "@graphql-tools/stitching-directives": "^1.2.0",
     "concurrently": "^5.3.0",
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",

--- a/stitching-directives-sdl/services/inventory/schema.graphql
+++ b/stitching-directives-sdl/services/inventory/schema.graphql
@@ -1,6 +1,9 @@
+"Stuff sitting in warehouse inventory"
 type Product @key(selectionSet: "{ upc }") {
   upc: ID!
+  "Specifies if this product is currently stocked."
   inStock: Boolean
+  "Specifies the estimated shipping cost of this product, in cents."
   shippingEstimate: Int @computed(selectionSet: "{ price weight }")
 }
 

--- a/stitching-directives-sdl/services/products/schema.graphql
+++ b/stitching-directives-sdl/services/products/schema.graphql
@@ -1,7 +1,12 @@
-type Product {
+"Represents a Product available for resale."
+type Product @canonical {
+  "The primary key of this product."
   upc: ID!
+  "The name of this product."
   name: String!
+  "The price of this product in cents."
   price: Int!
+  "The weight of this product in grams."
   weight: Int!
 }
 

--- a/stitching-directives-sdl/services/reviews/schema.graphql
+++ b/stitching-directives-sdl/services/reviews/schema.graphql
@@ -13,6 +13,7 @@ type User @key(selectionSet: "{ id }") {
 
 type Product @key(selectionSet: "{ upc }") {
   upc: ID!
+  "Reviews written for this product"
   reviews: [Review]
 }
 


### PR DESCRIPTION
A light nod to the new `@canonical` directive. This topic will be explored more thoroughly in a dedicated example once [merge validations](https://github.com/ardatan/graphql-tools/pull/2486) have been finalized and released.