### PR TITLE
Add support for yarn workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Guided examples of [Schema Stitching](https://www.graphql-tools.com/docs/stitch-
 
 ## Table of Contents
 
+### Installation
+
+From the root directory, run:
+
+```sh
+yarn install
+```
+
 ### Foundation
 
 - **[Combining local and remote schemas](./combining-local-and-remote-schemas)**
@@ -100,11 +108,13 @@ Guided examples of [Schema Stitching](https://www.graphql-tools.com/docs/stitch-
 - **[Subservice languages](./subservice-languages)**
 
   - **[JavaScript](./subservice-languages/javascript)** schemas created with:
+
     - `graphql-js`
     - `nexus`
     - `type-graphql`
 
   - **[Ruby](./subservice-languages/ruby)** schemas created with:
+
     - Class-based definitions
     - Parsed definitions string
 

--- a/custom-merge-resolvers/package.json
+++ b/custom-merge-resolvers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "type-merging-nullables",
+  "name": "custom-merge-resolvers",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/graphql-upload/package.json
+++ b/graphql-upload/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "combining-local-and-remote-schemas",
+  "name": "graphql-upload",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "workspaces": [
+    "combining-local-and-remote-schemas",
+    "computed-fields",
+    "continuous-integration-testing",
+    "custom-merge-resolvers",
+    "federation-services",
+    "graphql-upload",
+    "hot-schema-reloading",
+    "mutations-and-subscriptions",
+    "public-and-private-apis",
+    "stitching-directives-sdl",
+    "subservice-languages-javascript",
+    "subservice-languages-ruby",
+    "type-merging-arrays",
+    "type-merging-interfaces",
+    "type-merging-multiple-keys",
+    "type-merging-nullables",
+    "type-merging-single-records",
+    "versioning-schema-releases"
+  ]
+}

--- a/public-and-private-apis/package.json
+++ b/public-and-private-apis/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "curating-descriptions-and-fields",
+  "name": "public-and-private-apis",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/subservice-languages/javascript/package.json
+++ b/subservice-languages/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stitching-directives-sdl",
+  "name": "subservice-languages-javascript",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/subservice-languages/ruby/package.json
+++ b/subservice-languages/ruby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ruby-language-schema",
+  "name": "subservice-languages-ruby",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR adds support for yarn workspaces. This has two benefits:

- Dependencies for all subfolders can be installed with one command.
- Shared dependencies are only downloaded once, which saves space.

Users can still cd into a subfolder and run yarn install if they would prefer.